### PR TITLE
No escape for scope

### DIFF
--- a/Aminjam.Owin.Security/Aminjam.Owin.Security.Instagram/InstagramAuthenticationHandler.cs
+++ b/Aminjam.Owin.Security/Aminjam.Owin.Security.Instagram/InstagramAuthenticationHandler.cs
@@ -162,7 +162,7 @@ namespace Aminjam.Owin.Security.Instagram
                         "?response_type=code" +
                         "&client_id=" + Uri.EscapeDataString(Options.ClientId) +
                         "&redirect_uri=" + Uri.EscapeDataString(redirectUri) +
-                        "&scope=" + Uri.EscapeDataString(scope) +
+                        "&scope=" + scope +
                         "&state=" + Uri.EscapeDataString(state);
 
                 Response.Redirect(authorizationEndpoint);


### PR DESCRIPTION
because separator "+" for permisions list has to…be "+" in the generated dialog url.