### PR TITLE
Fix for instagram Bad Request during authentication

### DIFF
--- a/Aminjam.Owin.Security/Aminjam.Owin.Security.Instagram/InstagramAuthenticationHandler.cs
+++ b/Aminjam.Owin.Security/Aminjam.Owin.Security.Instagram/InstagramAuthenticationHandler.cs
@@ -70,7 +70,11 @@ namespace Aminjam.Owin.Security.Instagram
                                                     "&redirect_uri=" + Uri.EscapeDataString(redirectUri) +
                                                     "&client_id=" + Uri.EscapeDataString(Options.ClientId) +
                                                     "&client_secret=" + Uri.EscapeDataString(Options.ClientSecret));
-
+				
+				// Replace the default content-type so instagram parses postContent
+				postContent.Headers.Remove("Content-Type");
+                postContent.Headers.Add("Content-Type", "application/x-www-form-urlencoded");
+				
                 HttpResponseMessage tokenResponse =
                     await _httpClient.PostAsync(TokenEndpoint, postContent, Request.CallCancelled);
                 tokenResponse.EnsureSuccessStatusCode();


### PR DESCRIPTION
Instagram needs more exact headers for the post request getting the authorization_code or you will get a 400 Bad Request 

```
Id = 3500, Status = RanToCompletion, Method = "{null}", Result = "{\"code\": 400, \"error_type\": \"OAuthException\", \"error_message\": \"You must provide a client_id\"}"
```